### PR TITLE
fix: the wrong entrypoint in docker files

### DIFF
--- a/docker/wal-g/Dockerfile-mysql
+++ b/docker/wal-g/Dockerfile-mysql
@@ -74,4 +74,4 @@ COPY --from=bin-downloader /usr/bin/mysqlbinlog /usr/bin/mysqlbinlog
 
 USER 1000:1000
 
-ENTRYPOINT ["/user/bin/wal-g"]
+ENTRYPOINT ["/usr/bin/wal-g"]

--- a/docker/wal-g/Dockerfile-mysql-57-ubuntu
+++ b/docker/wal-g/Dockerfile-mysql-57-ubuntu
@@ -67,4 +67,4 @@ COPY --from=builder /wal-g /usr/bin/wal-g
 
 USER 1000:1000
 
-ENTRYPOINT ["/user/bin/wal-g"]
+ENTRYPOINT ["/usr/bin/wal-g"]

--- a/docker/wal-g/Dockerfile-mysql-ubuntu
+++ b/docker/wal-g/Dockerfile-mysql-ubuntu
@@ -66,4 +66,4 @@ COPY --from=builder /wal-g /usr/bin/wal-g
 
 USER 1000:1000
 
-ENTRYPOINT ["/user/bin/wal-g"]
+ENTRYPOINT ["/usr/bin/wal-g"]

--- a/docker/wal-g/Dockerfile-pg
+++ b/docker/wal-g/Dockerfile-pg
@@ -63,4 +63,4 @@ COPY --from=builder /wal-g /usr/bin/wal-g
 
 USER 1000:1000
 
-ENTRYPOINT ["/user/bin/wal-g"]
+ENTRYPOINT ["/usr/bin/wal-g"]


### PR DESCRIPTION
Fix incorrect entrypoint in Dockerfile, which prevents `docker run` from executing  